### PR TITLE
Add parameter for custom property-path delimiter.

### DIFF
--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -17,14 +17,14 @@ module HashDiff
   #   diff.should == [['-', 'x[0].c', 3], ['+', 'x[0].b', 2], ['-', 'x[1].y', 3], ['-', 'x[1]', {}]]
   #
   # @since 0.0.1
-  def self.best_diff(obj1, obj2)
-    diffs_1 = diff(obj1, obj2, "", 0.3)
+  def self.best_diff(obj1, obj2, delimiter='.')
+    diffs_1 = diff(obj1, obj2, "", 0.3, delimiter)
     count_1 = count_diff diffs_1
 
-    diffs_2 = diff(obj1, obj2, "", 0.5)
+    diffs_2 = diff(obj1, obj2, "", 0.5, delimiter)
     count_2 = count_diff diffs_2
 
-    diffs_3 = diff(obj1, obj2, "", 0.8)
+    diffs_3 = diff(obj1, obj2, "", 0.8, delimiter)
     count_3 = count_diff diffs_3
 
     count, diffs = count_1 < count_2 ? [count_1, diffs_1] : [count_2, diffs_2]
@@ -38,6 +38,7 @@ module HashDiff
   # @param [float] similarity A value > 0 and <= 1.
   #   This parameter should be ignored in common usage.
   #   Similarity is only meaningful if there're similar objects in arrays. See {best_diff}.
+  # @param [String] delimiter Delimiter for returned property-string
   #
   # @return [Array] an array of changes.
   #   e.g. [[ '+', 'a.b', '45' ], [ '-', 'a.c', '5' ], [ '~', 'a.x', '45', '63']]
@@ -50,7 +51,7 @@ module HashDiff
   #   diff.should == [['-', 'b.b1', 1], ['-', 'b.b2', 2]]
   #
   # @since 0.0.1
-  def self.diff(obj1, obj2, prefix = "", similarity = 0.8)
+  def self.diff(obj1, obj2, prefix = "", similarity = 0.8, delimiter='.')
     if obj1.nil? and obj2.nil?
       return []
     end
@@ -72,7 +73,7 @@ module HashDiff
       changeset = diff_array(obj1, obj2, similarity) do |lcs|
         # use a's index for similarity
         lcs.each do |pair|
-          result.concat(diff(obj1[pair[0]], obj2[pair[1]], "#{prefix}[#{pair[0]}]", similarity))
+          result.concat(diff(obj1[pair[0]], obj2[pair[1]], "#{prefix}[#{pair[0]}]", similarity, delimiter))
         end
       end
 
@@ -84,7 +85,7 @@ module HashDiff
         end
       end
     elsif obj1.is_a?(Hash)
-      prefix = prefix.empty? ? "" : "#{prefix}."
+      prefix = prefix.empty? ? "" : "#{prefix}#{delimiter}"
 
       deleted_keys = []
       common_keys = []
@@ -101,7 +102,7 @@ module HashDiff
       deleted_keys.each {|k| result << ['-', "#{prefix}#{k}", obj1[k]] }
 
       # recursive comparison for common keys
-      common_keys.each {|k| result.concat(diff(obj1[k], obj2[k], "#{prefix}#{k}", similarity)) }
+      common_keys.each {|k| result.concat(diff(obj1[k], obj2[k], "#{prefix}#{k}", similarity, delimiter)) }
 
       # added properties
       obj2.each do |k, v|

--- a/lib/hashdiff/patch.rb
+++ b/lib/hashdiff/patch.rb
@@ -7,13 +7,14 @@ module HashDiff
   #
   # @param [Hash, Array] obj the object to be patchted, can be an Array of a Hash
   # @param [Array] changes e.g. [[ '+', 'a.b', '45' ], [ '-', 'a.c', '5' ], [ '~', 'a.x', '45', '63']]
+  # @param [String] delimiter Property-string delimiter
   #
   # @return the object after patch
   #
   # @since 0.0.1
-  def self.patch!(obj, changes)
+  def self.patch!(obj, changes, delimiter='.')
     changes.each do |change|
-      parts = decode_property_path(change[1])
+      parts = decode_property_path(change[1], delimiter)
       last_part = parts.last
 
       parent_node = node(obj, parts[0, parts.size-1])
@@ -42,13 +43,14 @@ module HashDiff
   #
   # @param [Hash, Array] obj the object to be unpatchted, can be an Array of a Hash
   # @param [Array] changes e.g. [[ '+', 'a.b', '45' ], [ '-', 'a.c', '5' ], [ '~', 'a.x', '45', '63']]
+  # @param [String] delimiter Property-string delimiter
   #
   # @return the object after unpatch
   #
   # @since 0.0.1
-  def self.unpatch!(obj, changes)
+  def self.unpatch!(obj, changes, delimiter='.')
     changes.reverse_each do |change|
-      parts = decode_property_path(change[1])
+      parts = decode_property_path(change[1], delimiter)
       last_part = parts.last
 
       parent_node = node(obj, parts[0, parts.size-1])

--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -47,10 +47,12 @@ module HashDiff
   # @private
   #
   # decode property path into an array
+  # @param [String] path Property-string
+  # @param [String] delimiter Property-string delimiter
   #
   # e.g. "a.b[3].c" => ['a', 'b', 3, 'c']
-  def self.decode_property_path(path)
-    parts = path.split('.').collect do |part|
+  def self.decode_property_path(path, delimiter='.')
+    parts = path.split(delimiter).collect do |part|
       if part =~ /^(\w*)\[(\d+)\]$/
         if $1.size > 0
           [$1, $2.to_i]

--- a/spec/hashdiff/best_diff_spec.rb
+++ b/spec/hashdiff/best_diff_spec.rb
@@ -9,6 +9,15 @@ describe HashDiff do
     diff.should == [["-", "x[0].c", 3], ["+", "x[0].b", 2], ["-", "x[1]", {"y"=>3}]]
   end
 
+  it "should use custom delimiter when provided" do
+    a = {'x' => [{'a' => 1, 'c' => 3, 'e' => 5}, {'y' => 3}]}
+    b = {'x' => [{'a' => 1, 'b' => 2, 'e' => 5}] }
+
+    diff = HashDiff.best_diff(a, b, "\t")
+    diff.should == [["-", "x[0]\tc", 3], ["+", "x[0]\tb", 2], ["-", "x[1]", {"y"=>3}]]
+  end
+
+
   it "should be able to best diff array in hash" do
     a = {"menu" => {
       "id" => "file",

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -123,5 +123,13 @@ describe HashDiff do
     diff.should == [["-", "[0].d", 4], ["-", "[1]", {"x"=>5, "y"=>6, "z"=>3}]]
   end
 
+  it "should use custom delimiter when provided" do
+    a = [{'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}, {'x' => 5, 'y' => 6, 'z' => 3}, 3]
+    b = [{'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}, 3]
+
+    diff = HashDiff.diff(a, b, "", 0.8, "\t")
+    diff.should == [["-", "[0]\td", 4], ["-", "[1]", {"x"=>5, "y"=>6, "z"=>3}]]
+  end
+
 end
 

--- a/spec/hashdiff/util_spec.rb
+++ b/spec/hashdiff/util_spec.rb
@@ -6,6 +6,12 @@ describe HashDiff do
     decoded.should == ['a', 'b', 0, 'c', 'city', 5]
   end
 
+  it "should be able to decode property path with custom delimiter" do
+    decoded = HashDiff.send(:decode_property_path, "a\tb[0]\tc\tcity[5]", "\t")
+    decoded.should == ['a', 'b', 0, 'c', 'city', 5]
+  end
+
+
   it "should be able to tell similiar hash" do
     a = {'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}
     b = {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}


### PR DESCRIPTION
The default property-style output can be ambiguous:

  HashDiff.diff({'example.com'=>{'foo'=>'foo'}}, {'example.com'=>{'foo'=>'bar'}})
  => [["~", "example.com.foo", "foo", "bar"]]

This patch allows the user to provide a custom delimiter:

  HashDiff.diff({'example.com'=>{'foo'=>'foo'}}, {'example.com'=>{'foo'=>'bar'}}, "", 0.8, "\t")
  => [["~", "example.com\tfoo", "foo", "bar"]]
