### PR TITLE
Use a_start and b_start variables in HashDiff.lcs

### DIFF
--- a/lib/hashdiff/lcs.rb
+++ b/lib/hashdiff/lcs.rb
@@ -16,9 +16,9 @@ module HashDiff
     vector = []
 
     lcs = []
-    (0..b_finish).each do |bi|
+    (b_start..b_finish).each do |bi|
       lcs[bi] = [] 
-      (0..a_finish).each do |ai|
+      (a_start..a_finish).each do |ai|
         if similar?(a[ai], b[bi], opts)
           topleft = (ai > 0 and bi > 0)? lcs[bi-1][ai-1][1] : 0
           lcs[bi][ai] = [:topleft, topleft + 1]


### PR DESCRIPTION
These vars were already created at line 13 but they weren't used before.
This also fixes warnings when running script which uses hashdiff with ruby warnings turned on.