### PR TITLE
Add :case_insensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ HashDiff.unpatch!(b, diff).should == a
 
 ### Options
 
-There are five options available: `:delimiter`, `:similarity`, `:strict`, `:numeric_tolerance` and `:strip`.
+There are six options available: `:delimiter`, `:similarity`,
+`:strict`, `:numeric_tolerance`, `:strip` and `:case_insensitive`.
 
 #### `:delimiter`
 
@@ -130,6 +131,18 @@ a = {x:5, s:'foo '}
 b = {x:6, s:'foo'}
 
 diff = HashDiff.diff(a, b, :comparison => { :numeric_tolerance => 0.1, :strip => true })
+diff.should == [["~", "x", 5, 6]]
+```
+
+#### `:case_insensitive`
+
+The :case_insensitive option makes string comparisions ignore case.
+
+```ruby
+a = {x:5, s:'FooBar'}
+b = {x:6, s:'foobar'}
+
+diff = HashDiff.diff(a, b, :comparison => { :numeric_tolerance => 0.1, :case_insensitive => true })
 diff.should == [["~", "x", 5, 6]]
 ```
 

--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -90,9 +90,13 @@ module HashDiff
     end
 
     if options[:strip] == true
-      first = obj1.strip if obj1.respond_to?(:strip)
-      second = obj2.strip if obj2.respond_to?(:strip)
-      return first == second
+      obj1 = obj1.strip if obj1.respond_to?(:strip)
+      obj2 = obj2.strip if obj2.respond_to?(:strip)
+    end
+
+    if options[:case_insensitive] == true
+      obj1 = obj1.downcase if obj1.respond_to?(:downcase)
+      obj2 = obj2.downcase if obj2.respond_to?(:downcase)
     end
 
     obj1 == obj2

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -183,12 +183,37 @@ describe HashDiff do
     end
   end
 
+  context 'when :case_insensitive requested' do
+    it "should strip strings before comparing" do
+      a = { 'a' => "Foo", 'b' => "fizz buzz"}
+      b = { 'a' => "foo", 'b' => "fizzBuzz"}
+      diff = HashDiff.diff(a, b, :case_insensitive => true)
+      diff.should == [['~', 'b', "fizz buzz", "fizzBuzz"]]
+    end
+
+    it "should ignore case on nested strings before comparing" do
+      a = { 'a' => { 'x' => "Foo" }, 'b' => ["fizz buzz", "nerf"] }
+      b = { 'a' => { 'x' => "foo" }, 'b' => ["fizzbuzz", "nerf"] }
+      diff = HashDiff.diff(a, b, :case_insensitive => true)
+      diff.should == [['-', 'b[0]', "fizz buzz"], ['+', 'b[0]', "fizzbuzz"]]
+    end
+  end
+
   context 'when both :strip and :numeric_tolerance requested' do
     it 'should apply filters to proper object types' do
       a = { 'a' => " foo", 'b' => 35, 'c' => 'bar', 'd' => 'baz' }
       b = { 'a' => "foo", 'b' => 35.005, 'c' => 'bar', 'd' => 18.5}
       diff = HashDiff.diff(a, b, :strict => false, :numeric_tolerance => 0.01, :strip => true)
       diff.should == [['~', 'd', "baz", 18.5]]
+    end
+  end
+
+  context "when both :strip and :case_insensitive requested" do
+    it "should apply both filters to strings" do
+      a = { 'a' => " Foo", 'b' => "fizz buzz"}
+      b = { 'a' => "foo", 'b' => "fizzBuzz"}
+      diff = HashDiff.diff(a, b, :case_insensitive => true, :strip => true)
+      diff.should == [['~', 'b', "fizz buzz", "fizzBuzz"]]
     end
   end
 

--- a/spec/hashdiff/util_spec.rb
+++ b/spec/hashdiff/util_spec.rb
@@ -63,11 +63,16 @@ describe HashDiff do
 
     it 'should compare strings exactly by default' do
       expect(HashDiff.compare_values(' horse', 'horse')).to be_false
+      expect(HashDiff.compare_values('horse', 'Horse')).to be_false
     end
 
     it 'should strip strings before comparing when requested' do
       expect(HashDiff.compare_values(' horse', 'horse', :strip => true)).to be_true
     end
+
+    it "should ignore string case when requested" do
+      expect(HashDiff.compare_values('horse', 'Horse', :case_insensitive => true)).to be_true
+    end
+
   end
 end
-


### PR DESCRIPTION
This allows for easy string comparisons where you don't care about case.

Resolves #13 