### PR TITLE
Performance optimizations

### DIFF
--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -20,6 +20,8 @@ end
 
 class Hash
   def count_nodes
+    return @hd_node_count unless @hd_node_count.nil?
+
     count = 0
 
     self.each do |k, v|
@@ -28,6 +30,7 @@ class Hash
       end
     end
 
+    @hd_node_count = count
     count
   end
 end

--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -1,3 +1,37 @@
+class Object
+  def count_nodes
+    1
+  end
+end
+
+class Array
+  def count_nodes
+    count = 0
+
+    self.each do |e|
+      if e
+        count += e.count_nodes
+      end
+    end
+
+    count
+  end
+end
+
+class Hash
+  def count_nodes
+    count = 0
+
+    self.each do |k, v|
+      if v
+        count += v.count_nodes
+      end
+    end
+
+    count
+  end
+end
+
 module HashDiff
 
   # @private
@@ -33,17 +67,7 @@ module HashDiff
   # count total nodes for an object
   def self.count_nodes(obj)
     return 0 unless obj
-
-    count = 0
-    if obj.is_a?(Array)
-      obj.each {|e| count += count_nodes(e) }
-    elsif obj.is_a?(Hash)
-      obj.each {|k, v| count += count_nodes(v) }
-    else
-      return 1
-    end
-
-    count
+    obj.count_nodes
   end
 
   # @private


### PR DESCRIPTION
## Premise:
I've been using this library to compare very large hashes. The test hashes I used were both built from 10k+ lines of YAML and I found calculating the diff between the two hashes took around 90 seconds (304 seconds when profiling). I used [ruby-prof](https://github.com/ruby-prof/ruby-prof) to try and find some room for improvement, and managed to find a couple of easy wins.

## Changes:
- Instead of checking `is_a?`, extend `Object`, `Array` and `Hash` with their own `count_nodes` methods
  - This dropped the total time from 304 seconds to around 270
- Cache the count of the nodes in `Hash` objects 
  - This dropped the total time from 270 to about 197
  - There wasn't much to be gained from caching the count for `Array` objects
  - I think this is safe - from my understanding of the code, it does not add/remove objects from the original hashes so the count would not change after the first calculation

## Concerns:
Although this is a pretty significant time savings (for me at least - without profiling I dropped the calculation time from 90 seconds to about 65 seconds), extending/modifying classes and the original objects may be undesirable for whatever reason. I leave this up to your judgment @liufengyun.