### PR TITLE
Fix bug with array under hash key with non-word characters.

### DIFF
--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -55,7 +55,7 @@ module HashDiff
   # e.g. "a.b[3].c" => ['a', 'b', 3, 'c']
   def self.decode_property_path(path, delimiter='.')
     parts = path.split(delimiter).collect do |part|
-      if part =~ /^(\w*)\[(\d+)\]$/
+      if part =~ /^(.*)\[(\d+)\]$/
         if $1.size > 0
           [$1, $2.to_i]
         else

--- a/spec/hashdiff/patch_spec.rb
+++ b/spec/hashdiff/patch_spec.rb
@@ -61,6 +61,18 @@ describe HashDiff do
     HashDiff.unpatch!(b, diff).should == a
   end
 
+  it "should be able to patch array under hash key with non-word characters" do
+    a = {"a" => 1, "b-b" => [1, 2]}
+    b = {"a" => 1, "b-b" => [2, 1]}
+    diff = HashDiff.diff(a, b)
+
+    HashDiff.patch!(a, diff).should == b
+
+    a = {"a" => 1, "b-b" => [1, 2]}
+    b = {"a" => 1, "b-b" => [2, 1]}
+    HashDiff.unpatch!(b, diff).should == a
+  end
+
   it "should be able to patch hash value removal" do
     a = {"a" => 1, "b" => {"b1" => 1, "b2" =>2}}
     b = {"a" => 1}


### PR DESCRIPTION
A hash key with anything not matching \w (word characters) like -|, etc
would not match the regex detecting arrays in the patch path and would
not patch correctly.