### PR TITLE
Added option :max_diff_count to the diff function

### DIFF
--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -76,7 +76,7 @@ module HashDiff
       :delimiter   =>   '.',
       :strict      =>   true,
       :strip       =>   false,
-      :numeric_tolerance => 0,
+      :numeric_tolerance => 0
     }.merge!(options)
 
     opts[:comparison] = block if block_given?


### PR DESCRIPTION
IN some case when you are comparing really big hashes, you will encounter lot of out of memory exceptions when the gem is trying to print all results. (I am having big issues with it on Jruby). With this options you can specify, that the gem will print only first X errors and everything else will be ignored. I think that this option can be quite usefull.