### PR TITLE
fix an error when a hash has mixed types

### DIFF
--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -127,7 +127,7 @@ module HashDiff
       added_keys = obj2.keys - obj1.keys
 
       # add deleted properties
-      deleted_keys.sort.each do |k|
+      deleted_keys.sort_by{|k,v| k.to_s }.each do |k|
         custom_result = custom_compare(opts[:comparison], "#{prefix}#{k}", obj1[k], nil)
 
         if custom_result
@@ -138,10 +138,10 @@ module HashDiff
       end
 
       # recursive comparison for common keys
-      common_keys.sort.each {|k| result.concat(diff(obj1[k], obj2[k], opts.merge(:prefix => "#{prefix}#{k}"))) }
+      common_keys.sort_by{|k,v| k.to_s }.each {|k| result.concat(diff(obj1[k], obj2[k], opts.merge(:prefix => "#{prefix}#{k}"))) }
 
       # added properties
-      added_keys.sort.each do |k|
+      added_keys.sort_by{|k,v| k.to_s }.each do |k|
         unless obj1.key?(k)
           custom_result = custom_compare(opts[:comparison], "#{prefix}#{k}", nil, obj2[k])
 

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -22,6 +22,26 @@ describe HashDiff do
     diff.should == []
   end
 
+  it "should be able to diff two equal hashes with mixed key types" do
+    a = { 'a' => 1, :b => 1 }
+    diff = HashDiff.diff(a, a)
+    diff.should == []
+  end
+
+  it "should be able to diff if mixed key types are removed" do
+    a = { 'a' => 1, :b => 1 }
+    b = {}
+    diff = HashDiff.diff(a, b)
+    diff.should == [["-", "a", 1], ["-", "b", 1]]
+  end
+
+  it "should be able to diff if mixed key types are added" do
+    a = { 'a' => 1, :b => 1 }
+    b = {}
+    diff = HashDiff.diff(b, a)
+    diff.should == [["+", "a", 1], ["+", "b", 1]]
+  end
+
   it "should be able to diff two hashes with equivalent numerics, when strict is false" do
     diff = HashDiff.diff({ 'a' => 2.0, 'b' => 2 }, { 'a' => 2, 'b' => 2.0 }, :strict => false)
     diff.should == []


### PR DESCRIPTION
Hashdiff raises an ArgumentError if a hash contains mixed types:

h = {:a=> 1, 'b' => 2 }
HashDiff.best_diff(h, h)
ArgumentError: comparison of Symbol with String failed

This patch makes sure that sort compares the string representation of the objects. Tests are included.