### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In cases where you have similar hash objects in arrays, you can pass a custom va
 
 #### `:strict`
 
-The `:strict` option, which defaults to `true`, specifies whether numeric types are compared on type as well as value.  By default, a Fixnum will never be equal to a Float (e.g. 4 != 4.0).  Setting `:strict` to false makes the comparison looser (e.g. 4 == 4.0).
+The `:strict` option, which defaults to `true`, specifies whether numeric types are compared on type as well as value.  By default, an Integer will never be equal to a Float (e.g. 4 != 4.0).  Setting `:strict` to false makes the comparison looser (e.g. 4 == 4.0).
 
 #### `:numeric_tolerance`
 

--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -7,7 +7,7 @@ module HashDiff
   # @param [Array, Hash] obj1
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
-  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Fixnum, Float, BigDecimal to each other
+  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.
   #   * :strip (Boolean) [false] whether or not to call #strip on strings before comparing
@@ -48,7 +48,7 @@ module HashDiff
   # @param [Array, Hash] obj1
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
-  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Fixnum, Float, BigDecimal to each other
+  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
   #   * :similarity (Numeric) [0.8] should be between (0, 1]. Meaningful if there are similar hashes in arrays. See {best_diff}.
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.

--- a/lib/hashdiff/patch.rb
+++ b/lib/hashdiff/patch.rb
@@ -23,13 +23,13 @@ module HashDiff
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
@@ -62,13 +62,13 @@ module HashDiff
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

`warning: constant ::Fixnum is deprecated`

Thanks.