### PR TITLE
New rubies support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 script: "bundle exec rake spec"

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "http://rubygems.org"
 gemspec
 
 group :test do
-  gem 'rake'
+  gem 'rake', '< 11'
 end

--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -7,7 +7,7 @@ module HashDiff
   # @param [Array, Hash] obj1
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
-  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Fixnum, Float, BigDecimal to each other
+  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.
   #   * :strip (Boolean) [false] whether or not to call #strip on strings before comparing
@@ -48,7 +48,7 @@ module HashDiff
   # @param [Array, Hash] obj1
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
-  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Fixnum, Float, BigDecimal to each other
+  #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
   #   * :similarity (Numeric) [0.8] should be between (0, 1]. Meaningful if there are similar hashes in arrays. See {best_diff}.
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.

--- a/lib/hashdiff/patch.rb
+++ b/lib/hashdiff/patch.rb
@@ -23,13 +23,13 @@ module HashDiff
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
@@ -62,13 +62,13 @@ module HashDiff
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Fixnum)
+        if last_part.is_a?(Integer)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]


### PR DESCRIPTION
- Add 2.2, 2.3 and 2.4 to Travis CI.
- Modern version of `rake` fails with old RSpec so its version should be restricted.
- Fixnum is deprecated in Ruby 2.4.0 so replace it with Integer.