### PR TITLE
Use array path when delimiter is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ diff = HashDiff.diff(a, b, :delimiter => '\t')
 diff.should == [['-', 'a\tx', 2], ['-', 'a\tz', 4], ['-', 'b\tx', 3], ['~', 'b\tz', 45, 30], ['+', 'b\ty', 3]]
 ```
 
+You can also disable delimiters by passing `false`, and paths will be returned as an array:
+
+```ruby
+a = {a:{x:2, y:3, z:4}, b:{x:3, z:45}}
+b = {a:{y:3}, b:{y:3, z:30}}
+
+diff = HashDiff.diff(a, b, :delimiter => false)
+diff.should == [['-', ['a', 'x'], 2], ['-', ['a', 'z'], 4], ['-', ['b', 'x'], 3], ['~', ['b', 'z'], 45, 30], ['+', ['b', 'y'], 3]]
+```
+
+#### `:stringify_keys`
+
+By default, object keys are converted to strings in paths, you can override this behavior by specifying `:stringify_keys` as `false`.  This only works when `:delimiter` is false.
+
+```ruby
+a = {'a' => 1}
+b = {'a' => 1, :b => 2}
+
+diff = HashDiff.diff(a, b, :delimiter => false, :stringify_keys => false)
+diff.should == [['+', [:b], 2]]
+```
+
 #### `:similarity`
 
 In cases where you have similar hash objects in arrays, you can pass a custom value for `:similarity` instead of the default `0.8`.  This is interpreted as a ratio of similarity (default is 80% similar, whereas `:similarity => 0.5` would look for at least a 50% similarity).

--- a/lib/hashdiff/lcs.rb
+++ b/lib/hashdiff/lcs.rb
@@ -3,10 +3,8 @@ module HashDiff
   #
   # caculate array difference using LCS algorithm
   # http://en.wikipedia.org/wiki/Longest_common_subsequence_problem
-  def self.lcs(a, b, options = {})
-    opts = { :similarity => 0.8 }.merge!(options)
-
-    opts[:prefix] = "#{opts[:prefix]}[*]"
+  def self.lcs(a, b, options)
+    options = options.merge({:prefix => options[:prefix] + [-1]})
 
     return [] if a.size == 0 or b.size == 0
 
@@ -19,7 +17,7 @@ module HashDiff
     (b_start..b_finish).each do |bi|
       lcs[bi] = [] 
       (a_start..a_finish).each do |ai|
-        if similar?(a[ai], b[bi], opts)
+        if similar?(a[ai], b[bi], options)
           topleft = (ai > 0 and bi > 0)? lcs[bi-1][ai-1][1] : 0
           lcs[bi][ai] = [:topleft, topleft + 1]
         elsif

--- a/spec/hashdiff/diff_array_spec.rb
+++ b/spec/hashdiff/diff_array_spec.rb
@@ -5,7 +5,7 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 2, 3]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array(a, b, :prefix => [])
     diff.should == []
   end
 
@@ -13,48 +13,54 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 8, 7]
 
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['-', 2, 3], ['-', 1, 2], ['+', 1, 8], ['+', 2, 7]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['-', [2], 3], ['-', [1], 2], ['+', [1], 8], ['+', [2], 7]]
   end
 
   it "should be able to diff two arrays with nothing in common" do
     a = [1, 2]
     b = []
 
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['-', 1, 2], ['-', 0, 1]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['-', [1], 2], ['-', [0], 1]]
   end
 
   it "should be able to diff an empty array with an non-empty array" do
     a = []
     b = [1, 2]
 
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['+', 0, 1], ['+', 1, 2]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['+', [0], 1], ['+', [1], 2]]
   end
 
   it "should be able to diff two arrays with two elements in common" do
     a = [1, 3, 5, 7]
     b = [2, 3, 7, 5]
 
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['-', 0, 1], ['+', 0, 2], ['+', 2, 7], ['-', 4, 7]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['-', [0], 1], ['+', [0], 2], ['+', [2], 7], ['-', [4], 7]]
   end
 
   it "should be able to test two arrays with two common elements in different order" do
     a = [1, 3, 4, 7]
     b = [2, 3, 7, 5]
 
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['-', 0, 1], ['+', 0, 2], ['-', 2, 4], ['+', 3, 5]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['-', [0], 1], ['+', [0], 2], ['-', [2], 4], ['+', [3], 5]]
   end
 
   it "should be able to diff two arrays with similar elements" do
     a = [{'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}, 3]
     b = [1, {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}]
-    diff = HashDiff.diff_array(a, b)
-    diff.should == [['+', 0, 1], ['-', 2, 3]]
+    diff = HashDiff.diff_array(a, b, :prefix => [])
+    diff.should == [['+', [0], 1], ['-', [2], 3]]
   end
 
+  it "should return an array path if requested" do
+    a = [1, 2, 3]
+    b = [2, 3, 4]
+    diff = HashDiff.diff_array(a, b, :prefix => [], :delimiter => false)
+    diff.should == [['-', [0], 1], ['+', [2], 4]]
+  end
 end
 

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -163,6 +163,51 @@ describe HashDiff do
     diff.should == [["-", "[0]\td", 4], ["-", "[1]", {"x"=>5, "y"=>6, "z"=>3}]]
   end
 
+  context 'when :delimiter is false' do
+    it "should return an array path for a simple object" do
+      a = {'a' => 1}
+      b = {'a' => 1, 'b' => 2}
+      diff = HashDiff.diff(a, b, :delimiter => false)
+      diff.should == [['+', ['b'], 2]]
+    end
+
+    it "should return an array path for an object nested in an object" do
+      a = {'subobj' => {'a' => 1}}
+      b = {'subobj' => {'a' => 1, 'b' => 2}}
+      diff = HashDiff.diff(a, b, :delimiter => false)
+      diff.should == [['+', ['subobj', 'b'], 2]]
+    end
+
+    it "should return an array path for an object nested in an array" do
+      a = [{'a' => 1}]
+      b = [{'a' => 1, 'b' => 2}]
+      diff = HashDiff.diff(a, b, :delimiter => false)
+      diff.should == [['-', [0], {'a' => 1}], ['+', [0], {'a' => 1, 'b' => 2}]]
+    end
+
+    it "should return an array path for an array nested in an array" do
+      a = [[1]]
+      b = [[1, 2]]
+      diff = HashDiff.diff(a, b, :delimiter => false)
+      diff.should == [['-', [0], [1]], ['+', [0], [1, 2]]]
+    end
+
+    context 'when :stringify_keys is false' do
+      it "preserves symbol keys" do
+        a = {'a' => 1}
+        b = {'a' => 1, :b => 2}
+        diff = HashDiff.diff(a, b, :delimiter => false, :stringify_keys => false)
+        diff.should == [['+', [:b], 2]]
+      end
+      it "preserves object keys" do
+        a = {'a' => 1}
+        b = {'a' => 1, ['foo', 'bar'] => 2}
+        diff = HashDiff.diff(a, b, :delimiter => false, :stringify_keys => false)
+        diff.should == [['+', [['foo', 'bar']], 2]]
+      end
+    end
+  end
+
   context 'when :numeric_tolerance requested' do
     it "should be able to diff changes in hash value" do
       a = {'a' => 0.558, 'b' => 0.0, 'c' => 0.65, 'd' => 'fin'}

--- a/spec/hashdiff/lcs_spec.rb
+++ b/spec/hashdiff/lcs_spec.rb
@@ -5,7 +5,7 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 2, 3]
 
-    lcs = HashDiff.lcs(a, b)
+    lcs = HashDiff.lcs(a, b, :prefix => [], :similarity => 0.8)
     lcs.should == [[0, 0], [1, 1], [2, 2]]
   end
 
@@ -13,7 +13,7 @@ describe HashDiff do
     a = [1.05, 2, 3.25]
     b = [1.06, 2, 3.24]
 
-    lcs = HashDiff.lcs(a, b, :numeric_tolerance => 0.1)
+    lcs = HashDiff.lcs(a, b, :numeric_tolerance => 0.1, :prefix => [], :similarity => 0.8)
     lcs.should == [[0, 0], [1, 1], [2, 2]]
   end
 
@@ -21,7 +21,7 @@ describe HashDiff do
     a = ['foo', 'bar', 'baz']
     b = [' foo', 'bar', 'zab']
 
-    lcs = HashDiff.lcs(a, b, :strip => true)
+    lcs = HashDiff.lcs(a, b, :strip => true, :prefix => [], :similarity => 0.8)
     lcs.should == [[0, 0], [1, 1]]
   end
 
@@ -29,7 +29,7 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 8, 7]
 
-    lcs = HashDiff.lcs(a, b)
+    lcs = HashDiff.lcs(a, b, :prefix => [], :similarity => 0.8)
     lcs.should == [[0, 0]]
   end
 
@@ -37,7 +37,7 @@ describe HashDiff do
     a = [1, 3, 5, 7]
     b = [2, 3, 7, 5]
 
-    lcs = HashDiff.lcs(a, b)
+    lcs = HashDiff.lcs(a, b, :prefix => [], :similarity => 0.8)
     lcs.should == [[1, 1], [2, 3]]
   end
 
@@ -45,7 +45,7 @@ describe HashDiff do
     a = [1, 3.05, 5, 7]
     b = [2, 3.06, 7, 5]
 
-    lcs = HashDiff.lcs(a, b, :numeric_tolerance => 0.1)
+    lcs = HashDiff.lcs(a, b, :numeric_tolerance => 0.1, :prefix => [], :similarity => 0.8)
     lcs.should == [[1, 1], [2, 3]]
   end
 
@@ -53,7 +53,7 @@ describe HashDiff do
     a = [1, 3, 4, 7]
     b = [2, 3, 7, 5]
 
-    lcs = HashDiff.lcs(a, b)
+    lcs = HashDiff.lcs(a, b, :prefix => [], :similarity => 0.8)
     lcs.should == [[1, 1], [3, 2]]
   end
 
@@ -68,7 +68,7 @@ describe HashDiff do
           {"value" => "Close", "onclick" => "CloseDoc()"}
         ]
 
-    lcs = HashDiff.lcs(a, b, :similarity => 0.5)
+    lcs = HashDiff.lcs(a, b, :similarity => 0.5, :prefix => [])
     lcs.should == [[0, 0], [1, 2]]
   end
 end

--- a/spec/hashdiff/util_spec.rb
+++ b/spec/hashdiff/util_spec.rb
@@ -1,12 +1,28 @@
 require 'spec_helper'
 
 describe HashDiff do
-  it "should be able to decode property path" do
-    decoded = HashDiff.send(:decode_property_path, "a.b[0].c.city[5]")
+  it "should be able to encode property path with dot delimiter" do
+    encoded = HashDiff.send(:encode_property_path, ['a', 'b', 0, 'c', 'city', 5], '.')
+    encoded.should == "a.b[0].c.city[5]"
+  end
+
+  it "should be able to encode property path with tab delimiter" do
+    encoded = HashDiff.send(:encode_property_path, ['a', 'b', 0, 'c', 'city', 5], "\t")
+    encoded.should == "a\tb[0]\tc\tcity[5]"
+  end
+
+  # -1 is used internally for custom comparison callback paths in an array
+  it "should encode property path with -1 into a *" do
+    encoded = HashDiff.send(:encode_property_path, ['a', -1, 'b', 0], '.')
+    encoded.should == "a[*].b[0]"
+  end
+
+  it "should be able to decode property path with dot delimiter" do
+    decoded = HashDiff.send(:decode_property_path, "a.b[0].c.city[5]", '.')
     decoded.should == ['a', 'b', 0, 'c', 'city', 5]
   end
 
-  it "should be able to decode property path with custom delimiter" do
+  it "should be able to decode property path with tab delimiter" do
     decoded = HashDiff.send(:decode_property_path, "a\tb[0]\tc\tcity[5]", "\t")
     decoded.should == ['a', 'b', 0, 'c', 'city', 5]
   end
@@ -14,36 +30,36 @@ describe HashDiff do
   it "should be able to tell similiar hash" do
     a = {'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}
     b = {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}
-    HashDiff.similar?(a, b).should be true
-    HashDiff.similar?(a, b, :similarity => 1).should be false
+    HashDiff.similar?(a, b, :prefix => []).should be true
+    HashDiff.similar?(a, b, :similarity => 1, :prefix => []).should be false
   end
 
   it "should be able to tell similiar hash with values within tolerance" do
     a = {'a' => 1.5, 'b' => 2.25, 'c' => 3, 'd' => 4, 'e' => 5}
     b = {'a' => 1.503, 'b' => 2.22, 'c' => 3, 'e' => 5}
-    HashDiff.similar?(a, b, :numeric_tolerance => 0.05).should be true
-    HashDiff.similar?(a, b).should be false
+    HashDiff.similar?(a, b, :numeric_tolerance => 0.05, :prefix => []).should be true
+    HashDiff.similar?(a, b, :prefix => []).should be false
   end
 
   it "should be able to tell numbers and strings" do
-    HashDiff.similar?(1, 2).should be false
-    HashDiff.similar?("a", "b").should be false
-    HashDiff.similar?("a", [1, 2, 3]).should be false
-    HashDiff.similar?(1, {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}).should be false
+    HashDiff.similar?(1, 2, :prefix => []).should be false
+    HashDiff.similar?("a", "b", :prefix => []).should be false
+    HashDiff.similar?("a", [1, 2, 3], :prefix => []).should be false
+    HashDiff.similar?(1, {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}, :prefix => []).should be false
   end
 
   it "should be able to tell true when similarity == 0.5" do
     a = {"value" => "New1", "onclick" => "CreateNewDoc()"}
     b = {"value" => "New", "onclick" => "CreateNewDoc()"}
 
-    HashDiff.similar?(a, b, :similarity => 0.5).should be true
+    HashDiff.similar?(a, b, :similarity => 0.5, :prefix => []).should be true
   end
 
   it "should be able to tell false when similarity == 0.5" do
     a = {"value" => "New1", "onclick" => "open()"}
     b = {"value" => "New", "onclick" => "CreateNewDoc()"}
 
-    HashDiff.similar?(a, b, :similarity => 0.5).should be false
+    HashDiff.similar?(a, b, :similarity => 0.5, :prefix => []).should be false
   end
 
   describe '.compare_values' do


### PR DESCRIPTION
Addresses #19 and #25.

I went through some effort to make this backwards compatible - no external-facing behavior should be different using default options.  This could be made simpler by breaking the default behavior, so let me know which you would prefer.

User-facing changes:
* The `:delimiter` option now takes `false`, in which case, paths are returned as arrays rather than strings (#19).
* Added a new option `:stringify_keys`, defaulting to `true`.
  * When `false`, object keys will not be converted to strings in array paths.
  * This should allow for diffing of objects where symbol keys have meaning (#25).
  * This only applies if `:delimiter` is false.
* `patch!` and `unpatch!` work automatically with array paths, no option necessary.
* Added `README.md` description of new option values.

Internal changes:
* `:prefix` is now maintained in all relevant functions (most notably missing was `diff_array`).
  * When a change is added to the result set, it contains the fully qualified path and does not need an extra step to finalize it.
* Paths are now maintained internally as array paths rather than string paths.
  * When `:delimiter` is in effect, these paths will be translated to string paths at the API boundaries.
  * `'[*]'` in string paths is now `-1` in array paths (only exposed in comparison callbacks).
* Broke `diff_object` out of `diff`, similarly to `diff_array`.
* `diff` is now a wrapper for `diff_internal`
  * Primarily, this was to provide the API boundary for translating back to string paths.
  * Option default values are now applied once here, not every recursive call to `diff_internal`.
* Removed several default values on options (most weren't used except in tests).
  * Let me know if this is too intrusive, I may have gotten carried away.
* Added tests for the new behavior.


