### PR TITLE
Greatly improve performance of HashDiff#similar?

### DIFF
--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -4,6 +4,7 @@ module HashDiff
   #
   # judge whether two objects are similar
   def self.similar?(a, b, options = {})
+    return compare_values(a, b, options) unless a.is_a?(Array) || a.is_a?(Hash) || b.is_a?(Array) || b.is_a?(Hash)
     opts = { :similarity => 0.8 }.merge(options)
 
     count_a = count_nodes(a)


### PR DESCRIPTION
HashDiff#similar? compares values based on "node count" using
HashDiff#count_nodes and HashDiff#diff (if the counts don't cancel out). If
`a` and `b` are arrays/hashes `count_nodes` recursively counts the elements,
otherwise returns 1. If `a` and `b` are not arrays/hashes, HashDiff#similar?
needlessly counts/diffs values that will ultimately end up passing
through HashDiff#compare_values.

A considerable performance improvement can be had by circumventing the
needless recursion and call HashDiff#compare_values if `a` and `b` are
not arrays/hashes.

This has been benchmarked with this snippet:

```ruby
$LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
require 'hashdiff'
require 'benchmark'

seq1 = %w(a b c e h j l m n p)
seq2 = %w(a b c d e f j k l m r s t)

n = 10000
Benchmark.bm do |x|
   x.report('lcs') { n.times do ; HashDiff.lcs(seq1, seq2); end }
end
```

Before:

```sh
$ ruby benchmark.rb
       user     system      total        real
lcs  6.640000   0.010000   6.650000 (  6.649822)
```

After:

```sh
$ ruby benchmark.rb
       user     system      total        real
lcs  1.030000   0.010000   1.040000 (  1.037542)
```