### PR TITLE
Introduce an array_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ diff.should == [["~", "x", 5, 6]]
 
 #### `:case_insensitive`
 
-The :case_insensitive option makes string comparisions ignore case.
+The :case_insensitive option makes string comparisons ignore case.
 
 ```ruby
 a = {x:5, s:'FooBar'}

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ diff.should == [['-', 'a[0].x', 2], ['-', 'a[0].z', 4], ['-', 'a[1].y', 22], ['-
 patch example:
 
 ```ruby
-a = {a: 3}
-b = {a: {a1: 1, a2: 2}}
+a = {'a' => 3}
+b = {'a' => {'a1' => 1, 'a2' => 2}}
 
 diff = HashDiff.diff(a, b)
 HashDiff.patch!(a, diff).should == b
@@ -82,8 +82,8 @@ HashDiff.patch!(a, diff).should == b
 unpatch example:
 
 ```ruby
-a = [{a: 1, b: 2, c: 3, d: 4, e: 5}, {x: 5, y: 6, z: 3}, 1]
-b = [1, {a: 1, b: 2, c: 3, e: 5}]
+a = [{'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}, {'x' => 5, 'y' => 6, 'z' => 3}, 1]
+b = [1, {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}]
 
 diff = HashDiff.diff(a, b) # diff two array is OK
 HashDiff.unpatch!(b, diff).should == a

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ HashDiff.unpatch!(b, diff).should == a
 
 ### Options
 
-There are six options available: `:delimiter`, `:similarity`,
-`:strict`, `:numeric_tolerance`, `:strip` and `:case_insensitive`.
+There are seven options available: `:delimiter`, `:similarity`,
+`:strict`, `:numeric_tolerance`, `:strip`, `:case_insensitive`
+and `:array_path`.
 
 #### `:delimiter`
 
@@ -150,6 +151,39 @@ diff = HashDiff.diff(a, b, :comparison => { :numeric_tolerance => 0.1, :case_ins
 diff.should == [["~", "x", 5, 6]]
 ```
 
+#### `:array_path`
+
+The :array_path option represents the path of the diff in an array rather than
+a string. This can be used to show differences in between hash key types and
+is useful for `patch!` when used on hashes without string keys.
+
+```ruby
+a = {x:5}
+b = {'x'=>6}
+
+diff = HashDiff.diff(a, b, :array_path => true)
+diff.should == [['-', [:x], 5], ['+', ['x'], 6]]
+```
+
+For cases where there are arrays in paths their index will be added to the path.
+```ruby
+a = {x:[0,1]}
+b = {x:[0,2]}
+
+diff = HashDiff.diff(a, b, :array_path => true)
+diff.should == [["-", [:x, 1], 1], ["+", [:x, 1], 2]]
+```
+
+This shouldn't cause problems if you are comparing an array with a hash:
+
+```ruby
+a = {x:{0=>1}}
+b = {x:[1]}
+
+diff = HashDiff.diff(a, b, :array_path => true)
+diff.should == [["~", [:a], [1], {0=>1}]]
+```
+
 #### Specifying a custom comparison method
 
 It's possible to specify how the values of a key should be compared.
@@ -185,6 +219,8 @@ diff.should == [["~", "a", "car", "bus"], ["~", "b[1]", "plane", " plan"], ["-",
 ```
 
 When a comparison block is given, it'll be given priority over other specified options. If the block returns value other than `true` or `false`, then the two values will be compared with other specified options.
+
+When used in conjunction with the `array_path` option, the path passed in as an argument will be an array. When determining the ordering of an array a key of `"*"` will be used in place of the `key[*]` field. It is possible, if you have hashes with integer or `"*"` keys, to have problems distinguishing between arrays and hashes - although this shouldn't be an issue unless your data is very difficult to predict and/or your custom rules are very specific.
 
 #### Sorting arrays before comparison
 

--- a/lib/hashdiff/lcs.rb
+++ b/lib/hashdiff/lcs.rb
@@ -6,7 +6,7 @@ module HashDiff
   def self.lcs(a, b, options = {})
     opts = { :similarity => 0.8 }.merge!(options)
 
-    opts[:prefix] = "#{opts[:prefix]}[*]"
+    opts[:prefix] = prefix_append_array_index(opts[:prefix], '*', opts)
 
     return [] if a.size == 0 or b.size == 0
 

--- a/lib/hashdiff/patch.rb
+++ b/lib/hashdiff/patch.rb
@@ -1,4 +1,4 @@
-# 
+#
 # This module provides methods to diff two hash, patch and unpatch hash
 #
 module HashDiff
@@ -17,19 +17,21 @@ module HashDiff
     delimiter = options[:delimiter] || '.'
 
     changes.each do |change|
-      parts = decode_property_path(change[1], delimiter)
+      parts = change[1]
+      parts = decode_property_path(parts, delimiter) unless parts.is_a?(Array)
+
       last_part = parts.last
 
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Integer)
+        if parent_node.is_a?(Array)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Integer)
+        if parent_node.is_a?(Array)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
@@ -56,19 +58,21 @@ module HashDiff
     delimiter = options[:delimiter] || '.'
 
     changes.reverse_each do |change|
-      parts = decode_property_path(change[1], delimiter)
+      parts = change[1]
+      parts = decode_property_path(parts, delimiter) unless parts.is_a?(Array)
+
       last_part = parts.last
 
       parent_node = node(obj, parts[0, parts.size-1])
 
       if change[0] == '+'
-        if last_part.is_a?(Integer)
+        if parent_node.is_a?(Array)
           parent_node.delete_at(last_part)
         else
           parent_node.delete(last_part)
         end
       elsif change[0] == '-'
-        if last_part.is_a?(Integer)
+        if parent_node.is_a?(Array)
           parent_node.insert(last_part, change[2])
         else
           parent_node[last_part] = change[2]

--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -55,19 +55,17 @@ module HashDiff
   #
   # e.g. "a.b[3].c" => ['a', 'b', 3, 'c']
   def self.decode_property_path(path, delimiter='.')
-    parts = path.split(delimiter).collect do |part|
+    path.split(delimiter).inject([]) do |memo, part|
       if part =~ /^(.*)\[(\d+)\]$/
         if $1.size > 0
-          [$1, $2.to_i]
+          memo + [$1, $2.to_i]
         else
-          $2.to_i
+          memo + [$2.to_i]
         end
       else
-        part
+        memo + [part]
       end
     end
-
-    parts.flatten
   end
 
   # @private
@@ -127,6 +125,22 @@ module HashDiff
       elsif res == true
         return []
       end
+    end
+  end
+
+  def self.prefix_append_key(prefix, key, opts)
+    if opts[:array_path]
+      prefix + [key]
+    else
+      prefix.empty? ? "#{key}" : "#{prefix}#{opts[:delimiter]}#{key}"
+    end
+  end
+
+  def self.prefix_append_array_index(prefix, array_index, opts)
+    if opts[:array_path]
+      prefix + [array_index]
+    else
+      "#{prefix}[#{array_index}]"
     end
   end
 end

--- a/spec/hashdiff/best_diff_spec.rb
+++ b/spec/hashdiff/best_diff_spec.rb
@@ -62,4 +62,13 @@ describe HashDiff do
       ['+', 'menu.popup.menuitem[1]', {"value" => "Open", "onclick" => "OpenDoc()"}]
     ]
   end
+
+  it "should be able to have an array_path specified" do
+    a = {'x' => [{'a' => 1, 'c' => 3, 'e' => 5}, {'y' => 3}]}
+    b = {'x' => [{'a' => 1, 'b' => 2, 'e' => 5}] }
+
+    diff = HashDiff.best_diff(a, b, :array_path => true)
+    diff.should == [["-", ["x", 0, "c"], 3], ["+", ["x", 0, "b"], 2], ["-", ["x", 1], {"y"=>3}]]
+  end
+
 end

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -274,4 +274,40 @@ describe HashDiff do
       diff.should == [['~', 'b', 'boat', 'truck'], ['~', 'c', 'plane', ' plan']]
     end
   end
+
+  context 'when :array_path is true' do
+    it 'should return the diff path in an array rather than a string' do
+      x = { 'a' => 'foo' }
+      y = { 'a' => 'bar' }
+      diff = HashDiff.diff(x, y, :array_path => true)
+
+      diff.should == [['~', ['a'], 'foo', 'bar']]
+    end
+
+    it 'should show array indexes in paths' do
+      x = { 'a' => [0, 1, 2] }
+      y = { 'a' => [0, 1, 2, 3] }
+
+      diff = HashDiff.diff(x, y, :array_path => true)
+
+      diff.should == [['+', ['a', 3], 3]]
+    end
+
+    it 'should show differences with string and symbol keys' do
+      x = { 'a' => 'foo' }
+      y = { :a => 'bar' }
+
+      diff = HashDiff.diff(x, y, :array_path => true)
+      diff.should == [['-', ['a'], 'foo'], ['+', [:a], 'bar']]
+    end
+
+    it 'should support other key types' do
+      time = Time.now
+      x = { time => 'foo' }
+      y = { 0 => 'bar' }
+
+      diff = HashDiff.diff(x, y, :array_path => true)
+      diff.should == [['-', [time], 'foo'], ['+', [0], 'bar']]
+    end
+  end
 end

--- a/spec/hashdiff/patch_spec.rb
+++ b/spec/hashdiff/patch_spec.rb
@@ -157,5 +157,27 @@ describe HashDiff do
     HashDiff.unpatch!(b, diff, :delimiter => "\n").should == a
   end
 
+  it "should be able to patch when the diff is generated with an array_path" do
+    a = {"a" => 1, "b" => 1}
+    b = {"a" => 1, "b" => 2}
+    diff = HashDiff.diff(a, b, :array_path => true)
 
+    HashDiff.patch!(a, diff).should == b
+
+    a = {"a" => 1, "b" => 1}
+    b = {"a" => 1, "b" => 2}
+    HashDiff.unpatch!(b, diff).should == a
+  end
+
+  it "should be able to use non string keys when diff is generated with an array_path" do
+    a = {"a" => 1, :a => 2, 0 => 3}
+    b = {"a" => 5, :a => 6, 0 => 7}
+    diff = HashDiff.diff(a, b, :array_path => true)
+
+    HashDiff.patch!(a, diff).should == b
+
+    a = {"a" => 1, :a => 2, 0 => 3}
+    b = {"a" => 5, :a => 6, 0 => 7}
+    HashDiff.unpatch!(b, diff).should == a
+  end
 end


### PR DESCRIPTION
Hello :wave:, thanks for your work on this gem. We've found it useful.

This PR introduces an array_path option that can be used when generating a diff. This represents the path to aspects of the diff as an array rather than a string.

eg.
```
x = {'a' => 1}
y = {'a' => 2}

HashDiff.diff(x, y)
=> [["~", "a", 1, 2]]h

HashDiff.diff(x, y, :array_path => true)
=> [["~", ["a"], 1, 2]]
```

This allows there to be more flexibility with the types used as keys in a hash. Allowing workarounds for issues such as: https://github.com/liufengyun/hashdiff/issues/25

eg
```
x = {'a'=>1}
y = {:a=>1}
HashDiff.diff(x, y)
=> [["-", "a", 1], ["+", "a", 1]]
HashDiff.diff(x, y, :array_path => true)
=> [["-", ["a"], 1], ["+", [:a], 1]]
```

And improved ability to patch hashes with keys:

eg
```
x = {a: {b: :c}}
y = {a: {b: :d}}
diff = HashDiff.diff(x, y)
=> [["~", "a.b", :c, :d]]
HashDiff.patch!(x, diff)
    NoMethodError: undefined method `[]=' for nil:NilClass
diff = HashDiff.diff(x, y, array_path: true)
=> [["~", [:a, :b], :c, :d]]
HashDiff.patch!(x, diff)
=> {:a=>{:b=>:d}}
```

This updates the `patch!` and `unpatch!` methods to accept diffs with either paths as strings or as arrays.