### PR TITLE
Option to allow array comparisons in linear complexity

### DIFF
--- a/lib/hashdiff.rb
+++ b/lib/hashdiff.rb
@@ -1,5 +1,6 @@
 require 'hashdiff/util'
 require 'hashdiff/lcs'
+require 'hashdiff/linear_compare_array'
 require 'hashdiff/diff'
 require 'hashdiff/patch'
 require 'hashdiff/version'

--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -77,7 +77,8 @@ module HashDiff
       :strict      =>   true,
       :strip       =>   false,
       :numeric_tolerance => 0,
-      :array_path  =>   false
+      :array_path  =>   false,
+      :use_lcs     =>   true
     }.merge!(options)
 
     opts[:prefix] = [] if opts[:array_path] && opts[:prefix] == ''
@@ -105,8 +106,8 @@ module HashDiff
     end
 
     result = []
-    if obj1.is_a?(Array)
-      changeset = diff_array(obj1, obj2, opts) do |lcs|
+    if obj1.is_a?(Array) && opts[:use_lcs]
+      changeset = diff_array_lcs(obj1, obj2, opts) do |lcs|
         # use a's index for similarity
         lcs.each do |pair|
           prefix = prefix_append_array_index(opts[:prefix], pair[0], opts)
@@ -122,6 +123,8 @@ module HashDiff
           result << ['+', change_key, change[2]]
         end
       end
+    elsif obj1.is_a?(Array) && !opts[:use_lcs]
+      result.concat(LinearCompareArray.call(obj1, obj2, opts))
     elsif obj1.is_a?(Hash)
 
       deleted_keys = obj1.keys - obj2.keys
@@ -170,7 +173,7 @@ module HashDiff
   # @private
   #
   # diff array using LCS algorithm
-  def self.diff_array(a, b, options = {})
+  def self.diff_array_lcs(a, b, options = {})
     opts = {
       :prefix      =>   '',
       :similarity  =>   0.8,
@@ -223,5 +226,4 @@ module HashDiff
 
     change_set
   end
-
 end

--- a/lib/hashdiff/linear_compare_array.rb
+++ b/lib/hashdiff/linear_compare_array.rb
@@ -1,0 +1,155 @@
+module HashDiff
+  # @private
+  #
+  # Used to compare arrays in a linear complexity, which produces longer diffs
+  # than using the lcs algorithm but is considerably faster
+  class LinearCompareArray
+    def self.call(old_array, new_array, options = {})
+      instance = self.new(old_array, new_array, options)
+      instance.call
+    end
+
+    def call
+      return [] if old_array.empty? && new_array.empty?
+
+      self.old_index = 0
+      self.new_index = 0
+      # by comparing the array lengths we can expect that a number of items
+      # are either added or removed
+      self.expected_additions = new_array.length - old_array.length
+
+      loop do
+        if extra_items_in_old_array?
+          append_deletion(old_array[old_index], old_index)
+        elsif extra_items_in_new_array?
+          append_addition(new_array[new_index], new_index)
+        else
+          compare_at_index
+        end
+
+        self.old_index = old_index + 1
+        self.new_index = new_index + 1
+        break if iterated_through_both_arrays?
+      end
+
+      changes
+    end
+
+    private
+
+    attr_reader :old_array, :new_array, :options, :additions, :deletions, :differences
+    attr_accessor :old_index, :new_index, :expected_additions
+
+    def initialize(old_array, new_array, options)
+      @old_array = old_array
+      @new_array = new_array
+      @options = { prefix: '' }.merge!(options)
+
+      @additions = []
+      @deletions = []
+      @differences = []
+    end
+
+    def extra_items_in_old_array?
+      old_index < old_array.length && new_index >= new_array.length
+    end
+
+    def extra_items_in_new_array?
+      new_index < new_array.length && old_index >= old_array.length
+    end
+
+    def iterated_through_both_arrays?
+      old_index >= old_array.length && new_index >= new_array.length
+    end
+
+    def compare_at_index
+      difference = item_difference(old_array[old_index], new_array[new_index], old_index)
+      return if difference.empty?
+
+      index_after_additions = index_of_match_after_additions
+      append_addititions_before_match(index_after_additions)
+
+      index_after_deletions = index_of_match_after_deletions
+      append_deletions_before_match(index_after_deletions)
+
+      match = index_after_additions || index_after_deletions
+
+      append_differences(difference) unless match
+    end
+
+    def item_difference(old_item, new_item, item_index)
+      prefix = HashDiff.prefix_append_array_index(options[:prefix], item_index, options)
+      HashDiff.diff(old_item, new_item, options.merge(:prefix => prefix))
+    end
+
+    # look ahead in the new array to see if the current item appears later
+    # thereby having new items added
+    def index_of_match_after_additions
+      return unless expected_additions > 0
+
+      (1..expected_additions).each do |i|
+        next_difference = item_difference(
+          old_array[old_index],
+          new_array[new_index + i],
+          old_index
+        )
+
+        return new_index + i if next_difference.empty?
+      end
+
+      nil
+    end
+
+    # look ahead in the old array to see if the current item appears later
+    # thereby having items removed
+    def index_of_match_after_deletions
+      return unless expected_additions < 0
+
+      (1..(expected_additions.abs)).each do |i|
+        next_difference = item_difference(
+          old_array[old_index + i],
+          new_array[new_index],
+          old_index
+        )
+
+        return old_index + i if next_difference.empty?
+      end
+
+      nil
+    end
+
+    def append_addititions_before_match(match_index)
+      return unless match_index
+      (new_index...match_index).each { |i| append_addition(new_array[i], i) }
+      self.expected_additions = expected_additions - (match_index - new_index)
+      self.new_index = match_index
+    end
+
+    def append_deletions_before_match(match_index)
+      return unless match_index
+      (old_index...match_index).each { |i| append_deletion(old_array[i], i) }
+      self.expected_additions = expected_additions + (match_index - new_index)
+      self.old_index = match_index
+    end
+
+    def append_addition(item, index)
+      key = HashDiff.prefix_append_array_index(options[:prefix], index, options)
+      additions << ['+', key, item]
+    end
+
+    def append_deletion(item, index)
+      key = HashDiff.prefix_append_array_index(options[:prefix], index, options)
+      deletions << ['-', key, item]
+    end
+
+    def append_differences(difference)
+      differences.concat(difference)
+    end
+
+    def changes
+      # this algorithm only allows there to be additions or deletions
+      # deletions are reverse so they don't change the index of earlier items
+      differences + additions + deletions.reverse
+    end
+  end
+end

--- a/spec/hashdiff/diff_array_spec.rb
+++ b/spec/hashdiff/diff_array_spec.rb
@@ -5,7 +5,7 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 2, 3]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == []
   end
 
@@ -13,7 +13,7 @@ describe HashDiff do
     a = [1, 2, 3]
     b = [1, 8, 7]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['-', 2, 3], ['-', 1, 2], ['+', 1, 8], ['+', 2, 7]]
   end
 
@@ -21,7 +21,7 @@ describe HashDiff do
     a = [1, 2]
     b = []
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['-', 1, 2], ['-', 0, 1]]
   end
 
@@ -29,7 +29,7 @@ describe HashDiff do
     a = []
     b = [1, 2]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['+', 0, 1], ['+', 1, 2]]
   end
 
@@ -37,7 +37,7 @@ describe HashDiff do
     a = [1, 3, 5, 7]
     b = [2, 3, 7, 5]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['-', 0, 1], ['+', 0, 2], ['+', 2, 7], ['-', 4, 7]]
   end
 
@@ -45,14 +45,14 @@ describe HashDiff do
     a = [1, 3, 4, 7]
     b = [2, 3, 7, 5]
 
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['-', 0, 1], ['+', 0, 2], ['-', 2, 4], ['+', 3, 5]]
   end
 
   it "should be able to diff two arrays with similar elements" do
     a = [{'a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5}, 3]
     b = [1, {'a' => 1, 'b' => 2, 'c' => 3, 'e' => 5}]
-    diff = HashDiff.diff_array(a, b)
+    diff = HashDiff.diff_array_lcs(a, b)
     diff.should == [['+', 0, 1], ['-', 2, 3]]
   end
 

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -310,4 +310,30 @@ describe HashDiff do
       diff.should == [['-', [time], 'foo'], ['+', [0], 'bar']]
     end
   end
+
+  context 'when :use_lcs is false' do
+    it 'should show items in an array as changed' do
+      x = [:a, :b]
+      y = [:c, :d]
+      diff = HashDiff.diff(x, y, :use_lcs => false)
+
+      diff.should == [['~', '[0]', :a, :c], ['~', '[1]', :b, :d]]
+    end
+
+    it 'should show additions to arrays' do
+      x = { :a => [0] }
+      y = { :a => [0, 1] }
+      diff = HashDiff.diff(x, y, :use_lcs => false)
+
+      diff.should == [['+', 'a[1]', 1]]
+    end
+
+    it 'shows changes to nested arrays' do
+      x = { :a => [[0, 1]] }
+      y = { :a => [[1, 2]] }
+      diff = HashDiff.diff(x, y, :use_lcs => false)
+
+      diff.should == [['~', 'a[0][0]', 0, 1], ['~', 'a[0][1]', 1, 2]]
+    end
+  end
 end

--- a/spec/hashdiff/linear_compare_array_spec.rb
+++ b/spec/hashdiff/linear_compare_array_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe HashDiff::LinearCompareArray do
+  it "should find no differences between two empty arrays" do
+    difference = described_class.call([], [])
+    difference.should == []
+  end
+
+  it "should find added items when the old array is empty" do
+    difference = described_class.call([], [:a, :b])
+    difference.should == [['+', '[0]', :a], ['+', '[1]', :b]]
+  end
+
+  it "should find removed items when the new array is empty" do
+    difference = described_class.call([:a, :b], [])
+    difference.should == [['-', '[1]', :b], ['-', '[0]', :a]]
+  end
+
+  it "should find no differences between identical arrays" do
+    difference = described_class.call([:a, :b], [:a, :b])
+    difference.should == []
+  end
+
+  it "should find added items in an array" do
+    difference = described_class.call([:a, :d], [:a, :b, :c, :d])
+    difference.should == [['+', '[1]', :b], ['+', '[2]', :c]]
+  end
+
+  it "should find removed items in an array" do
+    difference = described_class.call([:a, :b, :c, :d, :e, :f], [:a, :d, :f])
+    difference.should == [['-', '[4]', :e], ['-', '[2]', :c], ['-', '[1]', :b]]
+  end
+
+  it "should show additions and deletions as changed items" do
+    difference = described_class.call([:a, :b, :c], [:c, :b, :a])
+    difference.should == [['~', '[0]', :a, :c], ['~', '[2]', :c, :a]]
+  end
+
+  it "should show changed items in a hash" do
+    difference = described_class.call([{ :a => :b }], [{ :a => :c }])
+    difference.should == [['~', '[0].a', :b, :c]]
+  end
+
+  it "should show changed items and added items" do
+    difference = described_class.call([{ :a => 1, :b => 2 }], [{ :a => 2, :b => 2 }, :item])
+    difference.should == [['~', '[0].a', 1, 2], ['+', '[1]', :item]]
+  end
+end


### PR DESCRIPTION
Hello again :wave:

We hit some problems using HashDiff in a web application at request time. We noticed the problem occurred when we were comparing arrays with lots of items in (909 length array with each item a hash) and noticed our request times spiking.

We traced this issue back to the approach used to work out the longest common subsequence. This PR introduces the ability to disable the LCS algorithm for a simpler one that runs at a linear complexity.

The LCS algorithm produces excellent diffs. Unfortunately it has a n<sup>2</sup> complexity which can lead to extremely slow computations on large arrays.

```
> require 'hashdiff';require 'benchmark'
> x = (1..100).map { |i| { key: i, foo: :bar } }
> puts Benchmark.measure { HashDiff.diff(x, x) }
  0.420000   0.000000   0.420000 (  0.430212)
```

If the size of the array is 1000 then we see it get really painful

```
> x = (1..1000).map { |i| { key: i, foo: :bar } }
> puts Benchmark.measure { HashDiff.diff(x, x) }
 42.680000   0.590000  43.270000 ( 43.530287)
```

This commit introduces an option to sacrifice the quality of the diff for a faster computational result with the `use_lcs` option, which can be set to false to disable use of the LCS algorithm.

With `use_lcs` as false the array comparison is much simpler with a complexity of at worst 2n for an array.

```
> x = (1..100).map { |i| { key: i, foo: :bar } }
> puts Benchmark.measure { HashDiff.diff(x, x, use_lcs: false) }
  0.010000   0.000000   0.010000 (  0.004894)
> x = (1..1000).map { |i| { key: i, foo: :bar } }
> puts Benchmark.measure { HashDiff.diff(x, x, use_lcs: false) }
  0.040000   0.000000   0.040000 (  0.042547)
```

The linear approach to comparing the array works on the basis that if arrays are the same length it treats the array as having no additions or deletions, only changes.

```
> HashDiff.diff([0,1,2], [3,4,5], use_lcs: false)
=> [["~", "[0]", 0, 3], ["~", "[1]", 1, 4], ["~", "[2]", 2, 5]]
```

compared to:

```
> HashDiff.diff([0,1,2], [3,4,5])
=> [["-", "[2]", 2], ["-", "[1]", 1], ["-", "[0]", 0], ["+", "[0]", 3], ["+", "[1]", 4], ["+", "[2]", 5]]
```

Whereas if there are more items in one array than the other it checks the items surrounding the index for a match to calculate additions and removals.

```
> HashDiff.diff([0, 3, 5], [0, 1, 2, 3, 4, 5], use_lcs: false)
=> [["+", "[1]", 1], ["+", "[2]", 2], ["+", "[4]", 4]]
> HashDiff.diff([0, 3, 5], [0, 1, 2, 3, 4, 5], use_lcs: false) == HashDiff.diff([0, 3, 5], [0, 1, 2, 3, 4, 5])
=> true
```

For a combination of added and changed items the diff will appear different to the LCS approach:

```
> HashDiff.diff([0, 1, 2], [0, 2, 2, 3], use_lcs: false)
=> [["~", "[1]", 1, 2], ["+", "[3]", 3]]
> HashDiff.diff([0, 1, 2], [0, 2, 2, 3])
=> [["-", "[1]", 1], ["+", "[1]", 2], ["+", "[3]", 3]]
```

However all diffs produce same results through `patch!` and `unpatch!` methods.