### PR TITLE
update minimum ruby to reflect actual support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.8
+  - 2.3.4
+  - 2.4.2
 script: "bundle exec rake spec"
+bundler_args: --retry 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,6 @@ rvm:
   - 2.3.4
   - 2.4.2
 script: "bundle exec rake spec"
-bundler_args: --retry 5
+
+before_install:
+  - gem install bundler

--- a/hashdiff.gemspec
+++ b/hashdiff.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- Appraisals {spec}/*`.split("\n")
 
   s.require_paths = ['lib']
-  s.required_ruby_version = Gem::Requirement.new(">= 1.8.7")
+  s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
   s.authors = ["Liu Fengyun"]
   s.email   = ["liufengyunchina@gmail.com"]


### PR DESCRIPTION
As noted on #38, commit a885a778b1afb9694f15939763cb1fd3d461ce2d includes code that will not work with ruby-1.8.7.  Updated the gemspec to reflect this so it doesn't get forgotten.  