### PR TITLE
Add rubygems links

### DIFF
--- a/hashdiff.gemspec
+++ b/hashdiff.gemspec
@@ -29,11 +29,11 @@ Gem::Specification.new do |s|
   
   if s.respond_to?(:metadata)
     s.metadata = {
-      "bug_tracker_uri"   => "https://github.com/liufengyun/hashdiff/issues",
-      "changelog_uri"     => "https://github.com/liufengyun/hashdiff/blob/master/changelog.md",
-      "documentation_uri" => "https://www.rubydoc.info/gems/hashdiff",
-      "homepage_uri"      => "https://github.com/liufengyun/hashdiff",
-      "source_code_uri"   => "https://github.com/liufengyun/hashdiff"
+      'bug_tracker_uri' => 'https://github.com/liufengyun/hashdiff/issues',
+      'changelog_uri' => 'https://github.com/liufengyun/hashdiff/blob/master/changelog.md',
+      'documentation_uri' => 'https://www.rubydoc.info/gems/hashdiff',
+      'homepage_uri' => 'https://github.com/liufengyun/hashdiff',
+      'source_code_uri' => 'https://github.com/liufengyun/hashdiff'
     }
   end
 end

--- a/hashdiff.gemspec
+++ b/hashdiff.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop')
   s.add_development_dependency('rubocop-rspec')
   s.add_development_dependency('yard')
-  
+
   if s.respond_to?(:metadata)
     s.metadata = {
       'bug_tracker_uri' => 'https://github.com/liufengyun/hashdiff/issues',

--- a/hashdiff.gemspec
+++ b/hashdiff.gemspec
@@ -26,4 +26,14 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rubocop')
   s.add_development_dependency('rubocop-rspec')
   s.add_development_dependency('yard')
+  
+  if s.respond_to?(:metadata)
+    s.metadata = {
+      "bug_tracker_uri"   => "https://github.com/liufengyun/hashdiff/issues",
+      "changelog_uri"     => "https://github.com/liufengyun/hashdiff/blob/master/changelog.md",
+      "documentation_uri" => "https://www.rubydoc.info/gems/hashdiff",
+      "homepage_uri"      => "https://github.com/liufengyun/hashdiff",
+      "source_code_uri"   => "https://github.com/liufengyun/hashdiff"
+    }
+  end
 end


### PR DESCRIPTION
This adds direct links on the rubygems website. It also helps with automated management of updates.