### PR TITLE
Release 1.0.0.beta1 With Deprecation Warnings and Shim Removed

### DIFF
--- a/hashdiff.gemspec
+++ b/hashdiff.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
   s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
-  s.post_install_message = 'The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.'
 
   s.authors = ['Liu Fengyun']
   s.email   = ['liufengyunchina@gmail.com']

--- a/lib/hashdiff.rb
+++ b/lib/hashdiff.rb
@@ -8,7 +8,3 @@ require 'hashdiff/linear_compare_array'
 require 'hashdiff/diff'
 require 'hashdiff/patch'
 require 'hashdiff/version'
-
-HashDiff = Hashdiff
-
-warn 'The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/45.'

--- a/lib/hashdiff/version.rb
+++ b/lib/hashdiff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hashdiff
-  VERSION = '0.4.0'.freeze
+  VERSION = '1.0.0.beta1'
 end


### PR DESCRIPTION
This PR will allow users who are annoyed by the deprecation warnings and/or those who have updated their code to reflect the constant change to manually specify the beta version in their `Gemfile` and remove them.

Like so:

```ruby
# Gemfile

gem 'hashdiff', ['>= 1.0.0.beta1', '< 2.0.0']
```