### PR TITLE
Fix failed CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.8
   - 2.3.4
   - 2.4.2
   - 2.5.3


### PR DESCRIPTION
Hi!

Since Rubocop recently drops Ruby 2.2 support ( [7026](https://github.com/rubocop-hq/rubocop/pull/7026) ), some specs fail in CI.

https://travis-ci.org/liufengyun/hashdiff/jobs/542366374

To fix the failed CI, this PR drops Ruby 2.2 and below in Travis.