### PR TITLE
Fix a RuboCop offense

### DIFF
--- a/lib/hashdiff/version.rb
+++ b/lib/hashdiff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hashdiff
-  VERSION = '1.0.0.beta1'
+  VERSION = '1.0.0.beta1'.freeze
 end


### PR DESCRIPTION
This PR fixes the following RuboCop offense when using Ruby 2.2 or lower.

```console
% bundle exec rake

(snip)

Running RuboCop...
Inspecting 20 files
.............C......
Offenses:
lib/hashdiff/version.rb:4:13: C: Style/MutableConstant: Freeze mutable
objects assigned to constants.
  VERSION = '1.0.0.beta1'
            ^^^^^^^^^^^^^
20 files inspected, 1 offense detected
RuboCop failed!
```

https://travis-ci.org/liufengyun/hashdiff/builds/546282876

This is a regression by https://github.com/liufengyun/hashdiff/pull/70.