### PR TITLE
Fix rubocop Style/FloatDivision violation

### DIFF
--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -16,7 +16,7 @@ module Hashdiff
 
     diffs = count_diff diff(obja, objb, opts)
 
-    (1 - diffs.to_f / (count_a + count_b).to_f) >= opts[:similarity]
+    (1 - diffs / (count_a + count_b).to_f) >= opts[:similarity]
   end
 
   # @private


### PR DESCRIPTION
This fixes the failing build (e.g. https://travis-ci.org/liufengyun/hashdiff/builds/558766332)