### PR TITLE
Make comparable? commutative

### DIFF
--- a/lib/hashdiff/util.rb
+++ b/lib/hashdiff/util.rb
@@ -107,6 +107,7 @@ module Hashdiff
   # check if objects are comparable
   def self.comparable?(obj1, obj2, strict = true)
     return true if (obj1.is_a?(Array) || obj1.is_a?(Hash)) && obj2.is_a?(obj1.class)
+    return true if (obj2.is_a?(Array) || obj2.is_a?(Hash)) && obj1.is_a?(obj2.class)
     return true if !strict && obj1.is_a?(Numeric) && obj2.is_a?(Numeric)
 
     obj1.is_a?(obj2.class) && obj2.is_a?(obj1.class)

--- a/spec/hashdiff/util_spec.rb
+++ b/spec/hashdiff/util_spec.rb
@@ -92,4 +92,24 @@ describe Hashdiff do
       expect(described_class.compare_values('horse', 'Horse', case_insensitive: true)).to be true
     end
   end
+
+  describe '.comparable?' do
+    it 'identifies hashes as comparable' do
+      expect(described_class.comparable?({}, {})).to be true
+    end
+
+    it 'identifies a subclass of Hash to be comparable with a Hash' do
+      OtherHash = Class.new(Hash)
+      expect(described_class.comparable?(OtherHash.new, {})).to be true
+    end
+
+    it 'identifies a Hash to be comparable with a subclass of Hash' do
+      OtherHash = Class.new(Hash)
+      expect(described_class.comparable?({}, OtherHash.new)).to be true
+    end
+
+    it 'does not identify a Numeric as comparable with a Hash' do
+      expect(described_class.comparable?(1, {})).to be false
+    end
+  end
 end


### PR DESCRIPTION
This fixes an issue where `comparable?(x, y)` != `comparable?(y, x)`, when x is an instance of a subclass of `Hash` (or `Array`), and y is an instance of `Hash` (or `Array`) directly.

Resolves https://github.com/liufengyun/hashdiff/issues/54