### PR TITLE
Add :indifferent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Hashdiff.unpatch!(b, diff).should == a
 ### Options
 
 There are eight options available: `:delimiter`, `:similarity`,
-`:strict`, `:numeric_tolerance`, `:strip`, `:case_insensitive`, `:array_path`
-and `:use_lcs`
+`:strict`, `:indifferent`, `:numeric_tolerance`, `:strip`, `:case_insensitive`,
+`:array_path` and `:use_lcs`
 
 #### `:delimiter`
 
@@ -117,6 +117,10 @@ In cases where you have similar hash objects in arrays, you can pass a custom va
 #### `:strict`
 
 The `:strict` option, which defaults to `true`, specifies whether numeric types are compared on type as well as value.  By default, an Integer will never be equal to a Float (e.g. 4 != 4.0).  Setting `:strict` to false makes the comparison looser (e.g. 4 == 4.0).
+
+#### `:indifferent`
+
+The `:indifferent` option, which defaults to `false`, specifies whether to treat hash keys indifferently.  Seting `:indifferent` to true has the effect of ignoring differences between symbol keys (ie. {a: 1} ~= {'a' => 1})
 
 #### `:numeric_tolerance`
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `:strict` option, which defaults to `true`, specifies whether numeric types 
 
 #### `:indifferent`
 
-The `:indifferent` option, which defaults to `false`, specifies whether to treat hash keys indifferently.  Seting `:indifferent` to true has the effect of ignoring differences between symbol keys (ie. {a: 1} ~= {'a' => 1})
+The `:indifferent` option, which defaults to `false`, specifies whether to treat hash keys indifferently.  Setting `:indifferent` to true has the effect of ignoring differences between symbol keys (ie. {a: 1} ~= {'a' => 1})
 
 #### `:numeric_tolerance`
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.1 2020-02-25
+
+* Add indifferent option
+
 ## v1.0.0 2019-06-06
 
 * Fix typo in readme (#72 @koic)

--- a/lib/hashdiff/compare_hashes.rb
+++ b/lib/hashdiff/compare_hashes.rb
@@ -7,13 +7,18 @@ module Hashdiff
     class << self
       def call(obj1, obj2, opts = {})
         return [] if obj1.empty? && obj2.empty?
-        if opts[:indifferent]
-          obj1 = obj1.with_indifferent_access
-          obj2 = obj2.with_indifferent_access
-        end
 
         obj1_keys = obj1.keys
         obj2_keys = obj2.keys
+        obj1_lookup = {}
+        obj2_lookup = {}
+
+        if opts[:indifferent]
+          obj1_lookup = obj1_keys.each_with_object({}) {|k, h| h[k.to_s] = k }
+          obj2_lookup = obj2_keys.each_with_object({}) {|k, h| h[k.to_s] = k }
+          obj1_keys = obj1_keys.map{|k| k.kind_of?(Symbol) ? k.to_s : k }
+          obj2_keys = obj2_keys.map{|k| k.kind_of?(Symbol) ? k.to_s : k }
+        end
 
         added_keys = (obj2_keys - obj1_keys).sort_by(&:to_s)
         common_keys = (obj1_keys & obj2_keys).sort_by(&:to_s)
@@ -23,6 +28,7 @@ module Hashdiff
 
         # add deleted properties
         deleted_keys.each do |k|
+          k = opts[:indifferent] ? obj1_lookup[k] : k
           change_key = Hashdiff.prefix_append_key(opts[:prefix], k, opts)
           custom_result = Hashdiff.custom_compare(opts[:comparison], change_key, obj1[k], nil)
 
@@ -37,13 +43,16 @@ module Hashdiff
         common_keys.each do |k|
           prefix = Hashdiff.prefix_append_key(opts[:prefix], k, opts)
 
-          result.concat(Hashdiff.diff(obj1[k], obj2[k], opts.merge(prefix: prefix)))
+          k1 = opts[:indifferent] ? obj1_lookup[k] : k
+          k2 = opts[:indifferent] ? obj2_lookup[k] : k
+          result.concat(Hashdiff.diff(obj1[k1], obj2[k2], opts.merge(prefix: prefix)))
         end
 
         # added properties
         added_keys.each do |k|
           change_key = Hashdiff.prefix_append_key(opts[:prefix], k, opts)
 
+          k = opts[:indifferent] ? obj2_lookup[k] : k
           custom_result = Hashdiff.custom_compare(opts[:comparison], change_key, nil, obj2[k])
 
           if custom_result

--- a/lib/hashdiff/compare_hashes.rb
+++ b/lib/hashdiff/compare_hashes.rb
@@ -14,10 +14,10 @@ module Hashdiff
         obj2_lookup = {}
 
         if opts[:indifferent]
-          obj1_lookup = obj1_keys.each_with_object({}) {|k, h| h[k.to_s] = k }
-          obj2_lookup = obj2_keys.each_with_object({}) {|k, h| h[k.to_s] = k }
-          obj1_keys = obj1_keys.map{|k| k.kind_of?(Symbol) ? k.to_s : k }
-          obj2_keys = obj2_keys.map{|k| k.kind_of?(Symbol) ? k.to_s : k }
+          obj1_lookup = obj1_keys.each_with_object({}) { |k, h| h[k.to_s] = k }
+          obj2_lookup = obj2_keys.each_with_object({}) { |k, h| h[k.to_s] = k }
+          obj1_keys = obj1_keys.map { |k| k.is_a?(Symbol) ? k.to_s : k }
+          obj2_keys = obj2_keys.map { |k| k.is_a?(Symbol) ? k.to_s : k }
         end
 
         added_keys = (obj2_keys - obj1_keys).sort_by(&:to_s)

--- a/lib/hashdiff/compare_hashes.rb
+++ b/lib/hashdiff/compare_hashes.rb
@@ -7,6 +7,10 @@ module Hashdiff
     class << self
       def call(obj1, obj2, opts = {})
         return [] if obj1.empty? && obj2.empty?
+        if opts[:indifferent]
+          obj1 = obj1.with_indifferent_access
+          obj2 = obj2.with_indifferent_access
+        end
 
         obj1_keys = obj1.keys
         obj2_keys = obj2.keys

--- a/lib/hashdiff/diff.rb
+++ b/lib/hashdiff/diff.rb
@@ -9,6 +9,7 @@ module Hashdiff
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
   #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
+  #   * :indifferent (Boolean) [false] whether to treat hash keys indifferently.  Set to true to ignore differences between symbol keys (ie. {a: 1} ~= {'a' => 1})
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.
   #   * :strip (Boolean) [false] whether or not to call #strip on strings before comparing
@@ -52,6 +53,7 @@ module Hashdiff
   # @param [Array, Hash] obj2
   # @param [Hash] options the options to use when comparing
   #   * :strict (Boolean) [true] whether numeric values will be compared on type as well as value.  Set to false to allow comparing Integer, Float, BigDecimal to each other
+  #   * :indifferent (Boolean) [false] whether to treat hash keys indifferently.  Set to true to ignore differences between symbol keys (ie. {a: 1} ~= {'a' => 1})
   #   * :similarity (Numeric) [0.8] should be between (0, 1]. Meaningful if there are similar hashes in arrays. See {best_diff}.
   #   * :delimiter (String) ['.'] the delimiter used when returning nested key references
   #   * :numeric_tolerance (Numeric) [0] should be a positive numeric value.  Value by which numeric differences must be greater than.  By default, numeric values are compared exactly; with the :tolerance option, the difference between numeric values must be greater than the given value.
@@ -79,6 +81,7 @@ module Hashdiff
       similarity: 0.8,
       delimiter: '.',
       strict: true,
+      indifferent: false,
       strip: false,
       numeric_tolerance: 0,
       array_path: false,

--- a/lib/hashdiff/version.rb
+++ b/lib/hashdiff/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Hashdiff
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -51,7 +51,7 @@ describe Hashdiff do
 
   it 'ignores string vs symbol differences, when indifferent is true' do
     diff = described_class.diff({ 'a' => 2, :b => 2 }, { :a => 2, 'b' => 2, :c => 3 }, indifferent: true)
-    diff.should == [["+", "c", 3]]
+    diff.should == [['+', 'c', 3]]
   end
 
   it 'is able to diff changes in hash value' do

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -50,8 +50,8 @@ describe Hashdiff do
   end
 
   it 'ignores string vs symbol differences, when indifferent is true' do
-    diff = described_class.diff({ 'a' => 2, :b => 2 }, { :a => 2, 'b' => 2 }, indifferent: true)
-    diff.should == []
+    diff = described_class.diff({ 'a' => 2, :b => 2 }, { :a => 2, 'b' => 2, :c => 3 }, indifferent: true)
+    diff.should == [["+", "c", 3]]
   end
 
   it 'is able to diff changes in hash value' do

--- a/spec/hashdiff/diff_spec.rb
+++ b/spec/hashdiff/diff_spec.rb
@@ -49,6 +49,11 @@ describe Hashdiff do
     diff.should == []
   end
 
+  it 'ignores string vs symbol differences, when indifferent is true' do
+    diff = described_class.diff({ 'a' => 2, :b => 2 }, { :a => 2, 'b' => 2 }, indifferent: true)
+    diff.should == []
+  end
+
   it 'is able to diff changes in hash value' do
     diff = described_class.diff({ 'a' => 2, 'b' => 3, 'c' => ' hello' }, 'a' => 2, 'b' => 4, 'c' => 'hello')
     diff.should == [['~', 'b', 3, 4], ['~', 'c', ' hello', 'hello']]


### PR DESCRIPTION
Added an option :indifferent to allow ignoring differences between strings and symbols as keys. This behaves similarly to the Rails/ActiveSupport Hash#with_indifferent_access modifier.

Included a spec and documentation.